### PR TITLE
Adds query by timestamp range

### DIFF
--- a/storage/src/main/java/zipkin2/storage/voltdb/Schema.java
+++ b/storage/src/main/java/zipkin2/storage/voltdb/Schema.java
@@ -31,14 +31,15 @@ final class Schema {
   static final String
       TABLE_SPAN = "span",
       PROCEDURE_STORE_SPAN = "storeSpanJson",
-      PROCEDURE_GET_SPAN = "getSpanJson";
+      PROCEDURE_GET_SPAN = "getSpanJson",
+      PROCEDURE_GET_SPANS = "getSpansJson";
 
-  static void ensureExists(Client client) {
+  static void ensureExists(Client client, String host) {
     try {
       executeAdHoc(client, "Select count(*) from " + Schema.TABLE_SPAN);
     } catch (ProcCallException e) {
       if (e.getMessage().contains("object not found")) {
-        LOG.info("Installing schema " + SCHEMA_RESOURCE);
+        LOG.info("Installing schema " + SCHEMA_RESOURCE + " on host " + host);
         applyCqlFile(client, SCHEMA_RESOURCE);
       }
     } catch (Exception e) {

--- a/storage/src/main/java/zipkin2/storage/voltdb/VoltDBStorage.java
+++ b/storage/src/main/java/zipkin2/storage/voltdb/VoltDBStorage.java
@@ -102,7 +102,7 @@ public final class VoltDBStorage extends StorageComponent {
         throw new RuntimeException("Unable to establish connection to VoltDB server", e);
       }
       if (ensureSchema) {
-        Schema.ensureExists(client);
+        Schema.ensureExists(client, host);
       } else {
         LOG.fine("Skipping schema check as ensureSchema was false");
       }

--- a/storage/src/main/java/zipkin2/storage/voltdb/internal/AggregateCall.java
+++ b/storage/src/main/java/zipkin2/storage/voltdb/internal/AggregateCall.java
@@ -30,6 +30,7 @@ import zipkin2.internal.Nullable;
 public abstract class AggregateCall<I, O> extends Call.Base<O> {
 
   public static Call<Void> create(List<Call<Void>> calls) {
+    if (calls.size() == 1) return calls.get(0);
     return new AggregateVoidCall(calls);
   }
 

--- a/storage/src/main/resources/ddl.sql
+++ b/storage/src/main/resources/ddl.sql
@@ -2,8 +2,9 @@ CREATE TABLE span
 (
   trace_id VARCHAR(32) NOT NULL,
   span_id VARCHAR(16) NOT NULL,
+  ts TIMESTAMP,
   md5 VARBINARY(16) NOT NULL,
-  json VARBINARY NOT NULL,
+  json VARCHAR NOT NULL,
   PRIMARY KEY (trace_id, span_id, md5)
 );
 
@@ -11,7 +12,10 @@ CREATE TABLE span
 PARTITION TABLE span ON COLUMN trace_id;
 
 CREATE PROCEDURE storeSpanJson PARTITION ON TABLE span COLUMN trace_id PARAMETER 0 AS
-  INSERT INTO span (trace_id, span_id, md5, json) VALUES (?, ?, ?, ?);
+  INSERT INTO span (trace_id, span_id, ts, md5, json) VALUES (?, ?, TO_TIMESTAMP(Micros, ?), ?, ?);
 
 CREATE PROCEDURE getSpanJson PARTITION ON TABLE span COLUMN trace_id PARAMETER 0 AS
   SELECT json from span where trace_id = ?;
+
+CREATE PROCEDURE getSpansJson AS
+  SELECT json from span where ts BETWEEN TO_TIMESTAMP(Millis, ?) AND TO_TIMESTAMP(Millis, ?);

--- a/storage/src/test/java/zipkin2/storage/voltdb/ITEnsureSchema.java
+++ b/storage/src/test/java/zipkin2/storage/voltdb/ITEnsureSchema.java
@@ -25,9 +25,10 @@ abstract class ITEnsureSchema {
   @Test public void installsTablesWhenMissing() throws Exception {
     executeAdHoc(client(), "Drop procedure " + Schema.PROCEDURE_STORE_SPAN);
     executeAdHoc(client(), "Drop procedure " + Schema.PROCEDURE_GET_SPAN);
+    executeAdHoc(client(), "Drop procedure " + Schema.PROCEDURE_GET_SPANS);
     executeAdHoc(client(), "Drop table " + Schema.TABLE_SPAN);
 
-    Schema.ensureExists(client());
+    Schema.ensureExists(client(), "localhost");
 
     executeAdHoc(client(), "Select count(*) from " + Schema.TABLE_SPAN);
   }

--- a/storage/src/test/java/zipkin2/storage/voltdb/ITVoltDBStorage.java
+++ b/storage/src/test/java/zipkin2/storage/voltdb/ITVoltDBStorage.java
@@ -14,14 +14,23 @@
 package zipkin2.storage.voltdb;
 
 import java.io.IOException;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.voltdb.client.Client;
+import zipkin2.Span;
 import zipkin2.TestObjects;
+import zipkin2.storage.QueryRequest;
+import zipkin2.storage.SpanStore;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+import static zipkin2.TestObjects.DAY;
+import static zipkin2.TestObjects.FRONTEND;
+import static zipkin2.TestObjects.TODAY;
 
 @RunWith(Enclosed.class)
 public class ITVoltDBStorage {
@@ -44,10 +53,110 @@ public class ITVoltDBStorage {
     @ClassRule public static VoltDBStorageRule voltdb = classRule();
 
     @Test public void checkWorks() throws IOException {
-      voltdb.storage.spanConsumer().accept(TestObjects.TRACE).execute();
+      accept(TestObjects.TRACE.toArray(new Span[0]));
 
-      assertThat(voltdb.storage.spanStore().getTrace(TestObjects.TRACE.get(0).traceId()).execute())
-        .containsExactlyInAnyOrderElementsOf(TestObjects.TRACE);
+      assertThat(store().getTrace(TestObjects.TRACE.get(0).traceId()).execute())
+          .containsExactlyInAnyOrderElementsOf(TestObjects.TRACE);
+    }
+
+    @Test public void dupesOk() throws IOException {
+      accept(TestObjects.TRACE.toArray(new Span[0]));
+      accept(TestObjects.TRACE.toArray(new Span[0]));
+
+      assertThat(store().getTrace(TestObjects.TRACE.get(0).traceId()).execute())
+          .containsExactlyInAnyOrderElementsOf(TestObjects.TRACE);
+    }
+
+    @Test public void checkMinimalSpan() throws IOException {
+      Span span = Span.newBuilder().traceId(-1L, 1L).id(1L).build();
+
+      accept(span);
+
+      assertThat(store().getTrace(span.traceId()).execute())
+          .containsExactly(span);
+    }
+
+    @Test public void getTrace_returnsEmptyOnNotFound() throws IOException {
+      assertThat(store().getTrace(CLIENT_SPAN.traceId()).execute())
+          .isEmpty();
+
+      accept(CLIENT_SPAN);
+
+      assertThat(store().getTrace(CLIENT_SPAN.traceId()).execute())
+          .containsExactly(CLIENT_SPAN);
+
+      assertThat(store().getTrace(CLIENT_SPAN.traceId().substring(16)).execute())
+          .isEmpty();
+    }
+
+    @Test public void getTraces_groupsTracesTogether() throws IOException {
+      Span traceASpan1 = Span.newBuilder()
+          .traceId("a")
+          .id("1")
+          .timestamp((TODAY + 1) * 1000L)
+          .localEndpoint(FRONTEND)
+          .build();
+      Span traceASpan2 = traceASpan1.toBuilder().id("1").timestamp((TODAY + 2) * 1000L).build();
+      Span traceBSpan1 = traceASpan1.toBuilder().traceId("b").build();
+      Span traceBSpan2 = traceASpan2.toBuilder().traceId("b").build();
+
+      accept(traceASpan1, traceBSpan1, traceASpan2, traceBSpan2);
+
+      assertThat(store().getTraces(requestBuilder().endTs(TODAY + 3).build()).execute())
+          .containsExactlyInAnyOrder(asList(traceASpan1, traceASpan2),
+              asList(traceBSpan1, traceBSpan2));
+    }
+
+    /** Traces whose root span has timestamps between (endTs - lookback) and endTs are returned */
+    @Test public void getTraces_endTsAndLookback() throws IOException {
+      Span span1 = Span.newBuilder()
+          .traceId("a")
+          .id("1")
+          .timestamp((TODAY + 1) * 1000L)
+          .localEndpoint(FRONTEND)
+          .build();
+      Span span2 = span1.toBuilder().traceId("b").timestamp((TODAY + 2) * 1000L).build();
+      accept(span1, span2);
+
+      assertThat(store().getTraces(requestBuilder().endTs(TODAY).build()).execute())
+          .isEmpty();
+      assertThat(store().getTraces(requestBuilder().endTs(TODAY + 1).build()).execute())
+          .extracting(t -> t.get(0).id())
+          .containsExactly(span1.id());
+      assertThat(store().getTraces(requestBuilder().endTs(TODAY + 2).build()).execute())
+          .extracting(t -> t.get(0).id())
+          .containsExactlyInAnyOrder(span1.id(), span2.id());
+      assertThat(store().getTraces(requestBuilder().endTs(TODAY + 3).build()).execute())
+          .extracting(t -> t.get(0).id())
+          .containsExactlyInAnyOrder(span1.id(), span2.id());
+
+      assertThat(store().getTraces(requestBuilder().endTs(TODAY).build()).execute())
+          .isEmpty();
+      assertThat(store().getTraces(requestBuilder().endTs(TODAY + 1).lookback(1).build()).execute())
+          .extracting(t -> t.get(0).id())
+          .containsExactly(span1.id());
+      assertThat(store().getTraces(requestBuilder().endTs(TODAY + 2).lookback(1).build()).execute())
+          .extracting(t -> t.get(0).id())
+          .containsExactlyInAnyOrder(span1.id(), span2.id());
+      assertThat(store().getTraces(requestBuilder().endTs(TODAY + 3).lookback(1).build()).execute())
+          .extracting(t -> t.get(0).id())
+          .containsExactlyInAnyOrder(span2.id());
+    }
+
+    @Before public void clear() throws Exception {
+      voltdb.clear();
+    }
+
+    static QueryRequest.Builder requestBuilder() {
+      return QueryRequest.newBuilder().endTs(TODAY + DAY).lookback(DAY * 2).limit(100);
+    }
+
+    void accept(Span... spans) throws IOException {
+      voltdb.storage.spanConsumer().accept(asList(spans)).execute();
+    }
+
+    SpanStore store() {
+      return voltdb.storage.spanStore();
     }
   }
 }

--- a/storage/src/test/resources/log4j2.properties
+++ b/storage/src/test/resources/log4j2.properties
@@ -8,4 +8,4 @@ rootLogger.appenderRefs=stdout
 rootLogger.appenderRef.stdout.ref=STDOUT
 # stop huge spam
 logger.dockerclient.name=org.testcontainers.dockerclient
-logger.dockerclient.level=debug
+logger.dockerclient.level=off


### PR DESCRIPTION
This adds support to lookup spans by timestamp range, using the native
date type which in VoltDB is conveniently microsecond capable.

This also polishes a few things, notably that the span json is stored as
a string which makes it possible to use with SQL operators. Also, this
ignores duplicate span upload requests rather than failing.