### PR TITLE
Set up VoltDB streaming to CSV text files

### DIFF
--- a/storage/src/main/resources/ddl.sql
+++ b/storage/src/main/resources/ddl.sql
@@ -12,6 +12,21 @@ CREATE TABLE span
   PRIMARY KEY (trace_id, id, md5)
 );
 
+-- Stream to export spans
+CREATE STREAM span_stream
+  PARTITION ON COLUMN trace_id
+  EXPORT TO TARGET spans (
+	  trace_id VARCHAR(32) NOT NULL,
+	  span_id VARCHAR(16) NOT NULL,
+	  service_name VARCHAR(255),
+	  name VARCHAR(255),
+	  ts TIMESTAMP,
+	  duration BIGINT,
+	  is_error TINYINT NOT NULL,
+	  md5 VARBINARY(16) NOT NULL,
+	  json VARCHAR NOT NULL
+);
+
 -- Allows procedures to work on a trace as a unit
 PARTITION TABLE span ON COLUMN trace_id;
 

--- a/voltdb.xml
+++ b/voltdb.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright 2019 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<deployment>
+	<cluster kfactor="0" />
+	<httpd enabled="true"/>
+	<export>
+	   <configuration enabled="true" target="spans" type="file">
+		 <property name="type">csv</property>
+		 <property name="nonce">ZFE</property>
+		 <property name="outdir">/tmp/export/</property>
+		 <property name="batched">false</property>
+		 <property name="skipinternals">true</property>
+	  </configuration>
+	</export>
+</deployment>


### PR DESCRIPTION
Run VoltDB with `voltdb.xml` as the deployment configuration. For
example if running in Docker:

```
docker run -p 8080:8080 -p 21212:21212 -e HOST_COUNT=1 \
  -v $PWD/voltdb.xml:/tmp/deployment.xml \
  -v /tmp/zipkin-voltdb-export:/tmp/export \
  voltdb/voltdb-community
```

`INSERT`ing any span into `span_stream` will now write it into a CSV
file in `/tmp/zipkin-voltdb-export/`. For example after injecting a few
spans with `error: 404`, running

```
INSERT INTO span_stream SELECT * FROM span;
```

Resulted in the following CSV file:

```
$ cat /tmp/zipkin-voltdb-export/active-ZFE-2935006470330171391-SPAN_STREAM-20190201125356.csv
bd7cfacf04993c","2abd7cfacf04993c","frontend","get","2019-02-01
12:53:55.149","1519","1","0908A226F41400FE3CE482B945462038","{""traceId"":""2abd7cfacf04993c"",""id"":""2abd7cfacf04993c"",""kind"":""SERVER"",""name"":""get"",""timestamp"":1549025635149022,""duration"":1519,""localEndpoint"":{""serviceName"":""frontend"",""ipv4"":""192.168.1.135""},""remoteEndpoint"":{""ipv6"":""::1"",""port"":59264},""tags"":{""error"":""404"",""http.method"":""GET"",""http.path"":""/tail/false"",""http.status_code"":""404""}}"
"15ccce4af9886694","15ccce4af9886694","frontend","get","2019-02-01
12:54:00.931","1012","1","63A1CA3053285FAC8F2FD3AE0F039F8B","{""traceId"":""15ccce4af9886694"",""id"":""15ccce4af9886694"",""kind"":""SERVER"",""name"":""get"",""timestamp"":1549025640931025,""duration"":1012,""localEndpoint"":{""serviceName"":""frontend"",""ipv4"":""192.168.1.135""},""remoteEndpoint"":{""ipv6"":""::1"",""port"":59267},""tags"":{""error"":""404"",""http.method"":""GET"",""http.path"":""/tail/false"",""http.status_code"":""404""}}"
```